### PR TITLE
Fixed `npm install` warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "gridster.js",
   "description": "a drag-and-drop multi-column jQuery grid plugin",
   "version": "0.6.9",
-  "homepage": "dsmorse.github.io/gridster.js/",
+  "homepage": "https://dsmorse.github.io/gridster.js/",
   "author": {
     "name": "ducksboard"
   },


### PR DESCRIPTION
npm WARN package.json gridster@0.6.9 homepage field must start with a protocol.