### PR TITLE
RoR gem missed the Engine files

### DIFF
--- a/lib/gridster.js-rails.rb
+++ b/lib/gridster.js-rails.rb
@@ -1,0 +1,7 @@
+require "bootstrap-typeahead-rails/version"
+
+module Gridster
+  module Rails
+    require "gridster.js-rails/engine"
+  end
+end

--- a/lib/gridster.js-rails/engine.rb
+++ b/lib/gridster.js-rails/engine.rb
@@ -1,0 +1,6 @@
+module Gridster
+  module Rails
+    class Engine < ::Rails::Engine
+    end
+  end
+end


### PR DESCRIPTION
Those two files got lost in the previous squash/merge but are required so that a Rails App loads the assets into it's pipeline.