### PR TITLE
Remove 'bootstrap-typeahead-rails' require statement

### DIFF
--- a/lib/gridster.js-rails.rb
+++ b/lib/gridster.js-rails.rb
@@ -1,5 +1,3 @@
-require "bootstrap-typeahead-rails/version"
-
 module Gridster
   module Rails
     require "gridster.js-rails/engine"


### PR DESCRIPTION
After adding `gem 'gridster.js-rails'` and running `bundle`, when I start `rails s` I got the following message: `bin/rails:6: warning: already initialized constant APP_PATH`

After a quick investigation I found out that the responsible statement is:
```ruby
require "bootstrap-typeahead-rails/version"
```

It seems that bootstrap-typeahead-rails is not used by gridster.js, so I propose this PR to fix the issue.