### PR TITLE
Fix the responsive grid to be able to shrink.

### DIFF
--- a/demos/responsive.html
+++ b/demos/responsive.html
@@ -21,7 +21,7 @@
                     enabled: true
                 }
             }).data('gridster');
-            $('.gridster  ul').css({'width': $(window).width()});
+            $('.gridster  ul').css({'padding': '0'});
         });
     </script>
 </head>

--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -3689,7 +3689,7 @@
 	 */
 	fn.get_responsive_col_width = function () {
 		var cols = this.cols || this.options.max_cols;
-		return (this.$el[0].scrollWidth - ((cols + 1) * this.options.widget_margins[0])) / cols;
+		return (this.$el[0].clientWidth - 3 - ((cols + 1) * this.options.widget_margins[0])) / cols;
 	};
 
 	/**


### PR DESCRIPTION
First of all, thanks @dsmorse for continuing to maintain this project!

There was a small regression, possibly introduced with 4936ef82c046, where the "responsive grid" demo gets into a state where the widgets only get wider, never narrower, forming an ever-expanding horizontal scrollbar (seen in both Chrome and Firefox, likely all browsers).

This is my attempt to fix.  Note I didn't include updated `dist` files, please rebuild those to see the effect.