### PR TITLE
Fire draggable.stop event after data attributes have been updated.

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -1586,10 +1586,6 @@
 		this.$player.coords().grid.row = row;
 		this.$player.coords().grid.col = col;
 
-		if (this.options.draggable.stop) {
-			this.options.draggable.stop.call(this, event, ui);
-		}
-
 		this.$player.addClass('player-revert').removeClass('player')
 				.attr({
 					'data-col': col,
@@ -1598,6 +1594,10 @@
 					'left': '',
 					'top': ''
 				});
+				
+		if (this.options.draggable.stop) {
+			this.options.draggable.stop.call(this, event, ui);
+		}
 
 		this.$preview_holder.remove();
 


### PR DESCRIPTION
All the other draggable methods update the data attributes then fire the event - .stop had been reordered. Without this change we are unable to get the new location after a drag has completed.