### PR TITLE
fix(fn.generate_stylesheet): only return with valid widths

### DIFF
--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -4707,7 +4707,8 @@
 
 		this.remove_style_tags();
 
-		return this.add_style_tag(styles);
+    /* only add_style_tag if the colWidth and $wrapper.width() are greater than 0 */
+    return (colWidth <= 0 || this.$wrapper.width() <= 0) ? this : this.add_style_tag(styles);
 	};
 
 


### PR DESCRIPTION
With responsive layouts, on window resize, colWidth and
this.$wrapper.width() can be <= 0. This causes widget widths to be set
as <= 0. I think it is fair to assume that both the colWidth and
$wrapper.width() must be greater than 0 in order to generate a valid
stylesheet.