### PR TITLE
Fix min width/height per widget not being calculated

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -791,45 +791,6 @@
 
 
 	/**
-	 * Change the dimensions of widgets.
-	 *
-	 * @method resize_widget_dimensions
-	 * @param {Object} [options] An Object with all options you want to
-	 *        overwrite:
-	 *    @param {Array} [options.widget_margins] Margin between widgets.
-	 *     The first index for the horizontal margin (left, right) and
-	 *     the second for the vertical margin (top, bottom).
-	 *    @param {Array} [options.widget_base_dimensions] Base widget dimensions
-	 *     in pixels. The first index for the width and the second for the
-	 *     height.
-	 * @return {Class} Returns the instance of the Gridster Class.
-	 */
-	fn.resize_widget_dimensions = function (options) {
-		if (options.widget_margins) {
-			this.options.widget_margins = options.widget_margins;
-		}
-
-		if (options.widget_base_dimensions) {
-			this.options.widget_base_dimensions = options.widget_base_dimensions;
-		}
-
-		this.min_widget_width = (this.options.widget_margins[0] * 2) + this.options.widget_base_dimensions[0];
-		this.min_widget_height = (this.options.widget_margins[1] * 2) + this.options.widget_base_dimensions[1];
-
-		this.$widgets.each($.proxy(function (i, widget) {
-			var $widget = $(widget);
-			this.resize_widget($widget);
-		}, this));
-
-		this.generate_grid_and_stylesheet();
-		this.get_widgets_from_DOM();
-		this.set_dom_grid_height();
-
-		return this;
-	};
-
-
-	/**
 	 * Mutate widget dimensions and position in the grid map.
 	 *
 	 * @method mutate_widget_in_gridmap
@@ -4035,6 +3996,9 @@
 		if (options.widget_base_dimensions) {
 			this.options.widget_base_dimensions = options.widget_base_dimensions;
 		}
+
+		this.min_widget_width = (this.options.widget_margins[0] * 2) + this.options.widget_base_dimensions[0];
+		this.min_widget_height = (this.options.widget_margins[1] * 2) + this.options.widget_base_dimensions[1];
 
 		this.$widgets.each($.proxy(function (i, widget) {
 			var $widget = $(widget);


### PR DESCRIPTION
The min width/height per widget isn't getting re-calculated when the gridster is resized via `resize_widget_dimensions`, which wrongly calculates the total height oh the gridster itself. This patch fixes this.

As a bonus, I removed a duplicated function which was doing half the things this function is doing.