### PR TITLE
fix bug with sticky position widgets

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -1536,13 +1536,23 @@
 
 		this.$changed = this.$changed.add(this.$player);
 
-		// move the cells down if there is an overlap and we are in static mode
-		if (this.options.collision.wait_for_mouseup) {
-			this.for_each_cell_occupied(this.placeholder_grid_data, function (tcol, trow) {
-				if (this.is_widget(tcol, trow)) {
-					this.move_widget_down(this.is_widget(tcol, trow), this.placeholder_grid_data.size_y);
-				}
-			});
+	    //If widget has new position, clean previous grid
+		if (this.placeholder_grid_data.el.coords().grid.col !== this.placeholder_grid_data.col ||
+            this.placeholder_grid_data.el.coords().grid.row !== this.placeholder_grid_data.row) {
+		    this.update_widget_position(this.placeholder_grid_data.el.coords().grid, false);
+
+		    // move the cells down if there is an overlap and we are in static mode
+		    if (this.options.collision.wait_for_mouseup) {
+		        this.for_each_cell_occupied(this.placeholder_grid_data, function (tcol, trow) {
+		            if (this.is_widget(tcol, trow)) {
+		                // get number of cells to move
+		                var destinyRow = this.placeholder_grid_data.row + this.placeholder_grid_data.size_y;
+		                var currentOverlappedRow = parseInt(this.gridmap[tcol][trow][0].getAttribute('data-row'));
+		                var cellsToMove = destinyRow - currentOverlappedRow;
+		                this.move_widget_down(this.is_widget(tcol, trow), cellsToMove);
+		            }
+		        });
+		    }
 		}
 
 		this.cells_occupied_by_player = this.get_cells_occupied(this.placeholder_grid_data);
@@ -1872,9 +1882,6 @@
 	fn.set_player = function (col, row, no_player) {
 		var self = this;
 		var swap = false;
-		if (!no_player) {
-			this.empty_cells_player_occupies();
-		}
 		var cell = !no_player ? self.colliders_data[0].el.data : {col: col};
 		var to_col = cell.col;
 		var to_row = cell.row || row;


### PR DESCRIPTION
Widget is removed from gridmap on_stop_drag only if changes its position
Overlapped widget is moved below the new position, taking into account the size of the widgets.

Closes #30