### PR TITLE
Add ignore_self_occupied option to allow gridster objects to be moved…

### DIFF
--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -977,7 +977,8 @@
 					handle_class: 'gs-resize-handle',
 					max_size: [Infinity, Infinity],
 					min_size: [1, 1]
-				}
+				},
+				ignore_self_occupied: false
 			};
 
 	/**
@@ -3302,6 +3303,9 @@
 		}
 
 		if (this.gridmap[col][row]) {
+			if(this.options.ignore_self_occupied) {
+				return this.$player.data() !== $(this.gridmap[col][row]).data();
+			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
… single columns/rows regardless of the size of the object itself.