### PR TITLE
Widget doesn't  auto move up when remove widget

### DIFF
--- a/src/jquery.gridster.js
+++ b/src/jquery.gridster.js
@@ -2356,9 +2356,7 @@
 	 */
 	fn.is_empty = function (col, row) {
 		if (typeof this.gridmap[col] !== 'undefined') {
-			if (typeof this.gridmap[col][row] !== 'undefined' &&
-					this.gridmap[col][row] === false
-			) {
+			if (!this.gridmap[col][row]) {
 				return true;
 			}
 			return false;


### PR DESCRIPTION
Widget doesn't  auto move up when removing widget like the follow image situation
![image](https://user-images.githubusercontent.com/20590125/31604325-935e6116-b228-11e7-8699-7affc0d612de.png)
Remove the test1 widget, the test2 widget will not auto move up.
**Root cause:**  **when initialize, the right part of the test1 widget is undefined. So when removing the test1 widget, it will judge the undefined part whether empty, but the is_empty function will return false, so the test2 widget will can't be moved up.**
![image](https://user-images.githubusercontent.com/20590125/31604537-408f508e-b229-11e7-8f1e-7422b8781fdb.png)
